### PR TITLE
Fix/main handler registering

### DIFF
--- a/AndroidStudioProject/unity/build.gradle
+++ b/AndroidStudioProject/unity/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
- Removed necessity of the message handler explicit registering in favor of its lazy loading ( which eliminates a problem when Unity callback may be sent on an unregistered handler )
-  Fixed "Compile SDK should not be lower than target SDK version" warning